### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Kandilli API
-[![Latest Version](https://pypip.in/version/kandilli/badge.svg)](https://pypi.python.org/pypi/kandilli/)
-[![Downloads](https://pypip.in/download/kandilli/badge.svg)](https://pypi.python.org/pypi/kandilli/)
-[![Download format](https://pypip.in/format/kandilli/badge.svg)](https://pypi.python.org/pypi/kandilli/)
-[![Supported Python versions](https://pypip.in/py_versions/kandilli/badge.svg)](https://pypi.python.org/pypi/kandilli/)
-[![License](https://pypip.in/license/kandilli/badge.svg)](https://pypi.python.org/pypi/kandilli/)
+[![Latest Version](https://img.shields.io/pypi/v/kandilli.svg)](https://pypi.python.org/pypi/kandilli/)
+[![Downloads](https://img.shields.io/pypi/dm/kandilli.svg)](https://pypi.python.org/pypi/kandilli/)
+[![Download format](https://img.shields.io/pypi/format/kandilli.svg)](https://pypi.python.org/pypi/kandilli/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/kandilli.svg)](https://pypi.python.org/pypi/kandilli/)
+[![License](https://img.shields.io/pypi/l/kandilli.svg)](https://pypi.python.org/pypi/kandilli/)
 [![Build Status](https://api.travis-ci.org/halitalptekin/kandilli.png)](https://travis-ci.org/halitalptekin/kandilli)
 
 Simple kandilli last earthquakes api.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20kandilli))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `kandilli`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.